### PR TITLE
Sensitive Driver Controls

### DIFF
--- a/src/main/java/frc/robot/commands/SensitiveDriverControl.java
+++ b/src/main/java/frc/robot/commands/SensitiveDriverControl.java
@@ -7,6 +7,8 @@
 
 package frc.robot.commands;
 
+import java.util.function.Supplier;
+
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.CommandBase;
@@ -23,6 +25,9 @@ public class SensitiveDriverControl extends CommandBase {
     private DriveBase driveBase;
     private Joystick joystick;
 
+    private final Supplier<Double> m_forwardVal;
+    private final Supplier<Double> m_rotateVal;
+
     public SensitiveDriverControl(Joystick joystick) {
         //set the drivebase
         this.driveBase = DriveBaseHolder.getInstance();
@@ -31,6 +36,9 @@ public class SensitiveDriverControl extends CommandBase {
 
         //Separation of concern- no other class uses this code
         new JoystickButton(joystick, XboxController.Button.kLeftBumper.value).whenHeld(this);        
+
+        m_forwardVal = () -> sign(Config.removeJoystickDeadband(joystick.getRawAxis(Config.LEFT_CONTROL_STICK_Y)), Config.INVERT_FIRST_AXIS);
+        m_rotateVal = () -> sign(Config.removeJoystickDeadband(joystick.getRawAxis(Config.RIGHT_CONTROL_STICK_X)), Config.INVERT_SECOND_AXIS);
     }
 
     /**
@@ -39,7 +47,8 @@ public class SensitiveDriverControl extends CommandBase {
     @Override
     public void execute() {
         this.driveBase.setSensitiveSteering(true);
-        this.driveBase.tankDrive(this.joystick.getRawAxis(Config.RIGHT_CONTROL_STICK_X)*Config.DRIVETRAIN_SENSITIVE_MAX_SPEED.get(), -this.joystick.getRawAxis(Config.RIGHT_CONTROL_STICK_X)*Config.DRIVETRAIN_SENSITIVE_MAX_SPEED.get(), false);
+        // this.driveBase.tankDrive(this.joystick.getRawAxis(Config.RIGHT_CONTROL_STICK_X)*Config.DRIVETRAIN_SENSITIVE_MAX_SPEED.get(), -this.joystick.getRawAxis(Config.RIGHT_CONTROL_STICK_X)*Config.DRIVETRAIN_SENSITIVE_MAX_SPEED.get(), false);
+        driveBase.arcadeDrive(m_forwardVal.get()*Config.DRIVETRAIN_SENSITIVE_FORWARD_SPEED, m_rotateVal.get()*Config.DRIVETRAIN_SENSITIVE_ROTATE_SPEED, true);
     }
 
     @Override
@@ -55,5 +64,22 @@ public class SensitiveDriverControl extends CommandBase {
     public void end(boolean interrupted) {
         this.driveBase.setSensitiveSteering(false);
         this.driveBase.stopMotors();
+    }
+
+    /**
+     * Stolen From ArcadeDriveWithJoystick.java
+     * Inverts a given double
+     *
+     * @param number The original number
+     * @param sign Weather or not to invert it
+     * @return The inverted value
+     */
+    private static double sign(double number, boolean sign){
+        if(sign){
+            return -number;
+        }
+        else{
+            return number;
+        }
     }
 }

--- a/src/main/java/frc/robot/config/Config.java
+++ b/src/main/java/frc/robot/config/Config.java
@@ -403,6 +403,9 @@ public class Config {
 
     public static FluidConstant<Integer> FEEDERSUBSYSTEM_IZONE = new FluidConstant<>("FeederSubsystemIZONE", 120)
                 .registerToTable(Config.constantsTable);
+
+    public static double DRIVETRAIN_SENSITIVE_FORWARD_SPEED = 0.5;
+    public static double DRIVETRAIN_SENSITIVE_ROTATE_SPEED = 0.2;
     
     //Sensor ports of analog inputs on Beetle
     public static final int MINIROBOT_MB1043_ANALOG_PORT = 4;


### PR DESCRIPTION
I almost forgot that Jamie asked for sensitive driver controls to slow down both the forward/backward and steering. (Before it was just slowing down steering).

Before merging this pull request, quickly deploy this branch and ask Jamie if it's good. LeftBumper is still the button for sensitive driving. Config can change how much it slows down.