### PR TITLE
Added CAN_TIMEOUT to setting drivetrain encoders

### DIFF
--- a/src/main/java/frc/robot/subsystems/DriveBase2020.java
+++ b/src/main/java/frc/robot/subsystems/DriveBase2020.java
@@ -295,8 +295,8 @@ public class DriveBase2020 extends DriveBase {
         }
 
         // Config the encoder and check if it worked
-        ErrorCode e1 = leftMaster.configSelectedFeedbackSensor(FeedbackDevice.CTRE_MagEncoder_Relative);
-        ErrorCode e2 = rightMaster.configSelectedFeedbackSensor(FeedbackDevice.CTRE_MagEncoder_Relative);
+        ErrorCode e1 = leftMaster.configSelectedFeedbackSensor(FeedbackDevice.CTRE_MagEncoder_Relative, Config.TALON_PRIMARY_PID, Config.CAN_TIMEOUT_LONG);
+        ErrorCode e2 = rightMaster.configSelectedFeedbackSensor(FeedbackDevice.CTRE_MagEncoder_Relative, Config.TALON_PRIMARY_PID, Config.CAN_TIMEOUT_LONG);
         
         if (e1.value != 0 || e2.value != 0) {
             state = DriveBaseState.Degraded;


### PR DESCRIPTION
The can timeout was defaulting to 0.

It says this in the comments by CTRE:
"Timeout value in ms. If nonzero, function will wait for config success and report an error if it times out. If zero, no blocking or checking is performed."

I'm worried that "no checking" means no error checking which means the RoboRio is not waiting to check if the encoder is actually there or not. We read the error returned by the function to see if the encoders are degraded or ok.

Added the usual 100ms timeout.

Delete this branch after merging.