### PR TITLE
Prevent color sensor calls when not needed.

### DIFF
--- a/src/main/java/frc/robot/subsystems/ColorSensorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ColorSensorSubsystem.java
@@ -126,12 +126,11 @@ public class ColorSensorSubsystem extends SubsystemBase {
     return colorSensor.getRawColor();
   }
 
-  public boolean isDetected() {
-    return bDetectedCargo;
-  }
+  // public boolean isDetected() {
+  //   return bDetectedCargo;
+  // }
 
-  @Override
-  public void periodic() {
+  public boolean isDetected() {
 
     //proximity sensor range: 1cm to 10cm
 
@@ -168,5 +167,6 @@ public class ColorSensorSubsystem extends SubsystemBase {
     detectBlue.setBoolean(isBlue);
    
     bDetectedCargo = isRed || isBlue;
+    return bDetectedCargo;
   }
 }


### PR DESCRIPTION
This small change means the color sensor will only be called when the code asks instead of always.
The code happens to always call the color sensor UNLESS the switch closest to the shooter is pressed.
Hopefully this break in color sensor calls can fix the issue described below.

In match 105 at DCMP, ColorSensorSubsystem.periodic() was reported at taking 0.35s.

Here is my detailed notes on what I found reading the driverstation logs:

Loop overrun message, displays time of each subsystem/command:
Match 68 -> All ColorSensorSubsystem.periodic were below 0.0025s
Match 95 -> All ColorSensorSubsystem.periodic were below 0.0025s
Match 105 Auto Period -> All ColorSensorSubsystem.periodic were below 0.0025s
Match 105 Tele Period -> ALL ColorSensorSubsystem.periodic were ABOVE 0.35s

The moment teleoperated started, ColorSensorSubsystem.periodic() was taking way too long to run.
Motor safety was saying "hey, I haven't gotten a new percent output for the drivetrain motors in awhile I'm going to stop the motors from moving." (I believe it is _likely_ that motor safety was causing the lapses in control. Likely being the key word, I can not confirm it since we seem to always get motor safety messages)

Battery Voltage reported from the driver station, voltage was a flat line for over 20 seconds :
Beginning of the match = 12.7 V
End of the match = 12.3 V

Number of reported brownouts = 7
Match 105 has the lowest number of recorded brownouts. (Match 105 = 7 brownouts, match 98 = 9 brownouts, match 25 = 10 brownouts, all other matches were >21 brownouts, match 68 has the highest number with 71 brownouts)